### PR TITLE
fixed goroutine leak after .Stop() is called

### DIFF
--- a/health_shared_test.go
+++ b/health_shared_test.go
@@ -45,8 +45,8 @@ func setupRunners(cfgs []*Config, logger loggers.ILogger) (*Health, []*Config, e
 	}
 
 	// Correct number of runners/tickers were created
-	if len(h.tickers) != len(cfgs) {
-		return nil, nil, fmt.Errorf("Start() did not create the expected number of tickers")
+	if len(h.runners) != len(cfgs) {
+		return nil, nil, fmt.Errorf("Start() did not create the expected number of runners")
 	}
 
 	return h, cfgs, nil


### PR DESCRIPTION
Woops - forgot that `ticker.Stop()` does not close the ticker channel (and thus the goroutine never exits).

Updated to use a stop channel instead.

Also reset the states map after `Stop()` - something that was missed before.