### PR TITLE
Fix global failed status when multiple fatal checks have mixed results

### DIFF
--- a/health.go
+++ b/health.go
@@ -97,6 +97,9 @@ type State struct {
 	// Err is the error returned from a failed health check
 	Err string `json:"error,omitempty"`
 
+	// Fatal shows if the check will affect global result
+	Fatal bool `json:"fatal,omitempty"`
+
 	// Details contains more contextual detail about a
 	// failing health check.
 	Details interface{} `json:"details,omitempty"` // contains JSON message (that can be marshaled)
@@ -247,6 +250,7 @@ func (h *Health) startRunner(cfg *Config, ticker *time.Ticker, stop <-chan struc
 			Status:    "ok",
 			Details:   data,
 			CheckTime: time.Now(),
+			Fatal:     cfg.Fatal,
 		}
 
 		if err != nil {

--- a/health.go
+++ b/health.go
@@ -124,7 +124,6 @@ type Health struct {
 	StatusListener IStatusListener
 
 	active     *sBool // indicates whether the healthcheck is actively running
-	failed     *sBool // indicates whether the healthcheck has encountered a fatal error in one of its deps
 	configs    []*Config
 	states     map[string]State
 	statesLock sync.Mutex
@@ -139,7 +138,6 @@ func New() *Health {
 		states:     make(map[string]State, 0),
 		runners:    make(map[string]chan struct{}, 0),
 		active:     newBool(),
-		failed:     newBool(), // init as false
 		statesLock: sync.Mutex{},
 	}
 }
@@ -267,11 +265,6 @@ func (h *Health) startRunner(cfg *Config, ticker *time.Ticker, stop <-chan struc
 
 			stateEntry.Err = err.Error()
 			stateEntry.Status = "failed"
-		}
-
-		// Toggle the global failed state if check is configured as fatal
-		if cfg.Fatal {
-			h.failed.set(err != nil)
 		}
 
 		h.safeUpdateState(stateEntry)

--- a/health.go
+++ b/health.go
@@ -230,13 +230,18 @@ func (h *Health) Stop() error {
 //
 // The map key is the name of the check.
 func (h *Health) State() (map[string]State, bool, error) {
-	return h.safeGetStates(), h.failed.val(), nil
+	return h.safeGetStates(), h.Failed(), nil
 }
 
 // Failed will return the basic state of overall health. This should be used when
 // details about the failure are not needed
 func (h *Health) Failed() bool {
-	return h.failed.val()
+	for _, val := range h.safeGetStates() {
+		if val.Fatal && val.isFailure() {
+			return true
+		}
+	}
+	return false
 }
 
 func (h *Health) startRunner(cfg *Config, ticker *time.Ticker, stop <-chan struct{}) {

--- a/health_test.go
+++ b/health_test.go
@@ -433,7 +433,7 @@ func TestStartRunner(t *testing.T) {
 		}
 
 		// Since nothing has failed, healthcheck should _not_ be in failed state
-		Expect(h.failed.val()).To(BeFalse())
+		Expect(h.Failed()).To(BeFalse())
 	})
 
 	t.Run("Happy path - no checkers is noop", func(t *testing.T) {
@@ -488,7 +488,7 @@ func TestStartRunner(t *testing.T) {
 		Expect(h.states[cfgs[1].Name].Err).To(Equal(checker2Error.Error()))
 
 		// Since nothing has failed, healthcheck should _not_ be in failed state
-		Expect(h.failed.val()).To(BeFalse())
+		Expect(h.Failed()).To(BeFalse())
 	})
 
 	t.Run("Happy path - 1 checker fails (fatal)", func(t *testing.T) {
@@ -532,7 +532,7 @@ func TestStartRunner(t *testing.T) {
 		Expect(h.states[cfgs[1].Name].Err).To(Equal(checker2Err.Error()))
 
 		// Since second checker has failed fatally, global healthcheck state should be failed as well
-		Expect(h.failed.val()).To(BeTrue())
+		Expect(h.Failed()).To(BeTrue())
 	})
 }
 

--- a/health_test.go
+++ b/health_test.go
@@ -169,8 +169,17 @@ func TestFailed(t *testing.T) {
 		h := setupNewTestHealth()
 		checker1 := &fakes.FakeICheckable{}
 		checker1.StatusReturns(nil, fmt.Errorf("things broke"))
+		checker2 := &fakes.FakeICheckable{}
+		checker2.StatusReturns(nil, nil)
 
 		cfgs := []*Config{
+			// order *is* relevant, failing check should be first
+			{
+				Name:     "bar",
+				Checker:  checker2,
+				Interval: testCheckInterval,
+				Fatal:    true,
+			},
 			{
 				Name:     "foo",
 				Checker:  checker1,
@@ -235,8 +244,17 @@ func TestState(t *testing.T) {
 		h := setupNewTestHealth()
 		checker1 := &fakes.FakeICheckable{}
 		checker1.StatusReturns(nil, fmt.Errorf("things broke"))
+		checker2 := &fakes.FakeICheckable{}
+		checker2.StatusReturns(nil, nil)
 
 		cfgs := []*Config{
+			// order *is* relevant, failing check should be first
+			{
+				Name:     "bar",
+				Checker:  checker2,
+				Interval: testCheckInterval,
+				Fatal:    true,
+			},
 			{
 				Name:     "foo",
 				Checker:  checker1,


### PR DESCRIPTION
Hello, first of all thank you for this library!

I really like the effective and simple implementation.

I found a bug that I suspect is a race condition in the global status when there are multiple fatal checks with mixed order.

Given the presence of multiple fatal checks, some failing and some passing, if the order of execution makes the passing check end last the global status was reported as `ok` even if other `fatal` check were in a `failed` state.

Looking at the code, each goroutine was updating the `h.failed` "thread-global" variable at the end of it's check cycle. This makes the `h.failed` variable to have the last value set by a goroutine in order of exectuion *time*.
If a successful fatal test run after a failing one, the `h.failed` variable was reporting `true`.

To reproduce the bug I updated the test cases 
```
TestFailed/
  Should_return_false_if_a_fatally_configured_check_hasn't_errored
```
and
```
TestState/
  When_a_fatally-configured_check_fails_and_recovers,_state_should_get_updated_accordingly
```
to use two checkers instead of one, both fatal but one failing and one passing, ordered such that the passing check was executed after the failing one.  
( You can still test this at commit 1fa23aa )

This PR adds a little feature and implements a fix for this behaviour.

#### Feature 
Add `Fatal` field in the `State` struct.  
This information is really helpful when multiple checks (mixed fatal and not fatal) are present and the global status is `failed`.  
With this information exposed is clear which check is making the global status to fail.  

The bugfix is based upon the `Fatal` field exposed in the `State` struct, this could be reworked but I found the `Fatal` to be useful there anyway.

#### Bugfix
Remove the `h.failed` boolean and rely only on `State` information to evaluate the condition.  
With this implementation the `h.Failed()` function relies on `safeGetStates`  to reported last known status.

Thank you for looking into this!