### PR TITLE
Move checkers with external deps into sub packages

### DIFF
--- a/checkers/disk/disk_usage.go
+++ b/checkers/disk/disk_usage.go
@@ -1,7 +1,8 @@
-package checkers
+package diskchk
 
 import (
 	"fmt"
+
 	"github.com/shirou/gopsutil/disk"
 )
 
@@ -13,8 +14,8 @@ import (
 // "CriticalThreshold" is _required_; set percent (more than 0 and less 100) of free space at specified path,
 //  which triggers critical.
 type DiskUsageConfig struct {
-	Path string
-	WarningThreshold float64
+	Path              string
+	WarningThreshold  float64
 	CriticalThreshold float64
 }
 
@@ -23,7 +24,7 @@ type DiskUsage struct {
 	Config *DiskUsageConfig
 }
 
-func NewDiskUsage(cfg *DiskUsageConfig) (*DiskUsage, error)  {
+func NewDiskUsage(cfg *DiskUsageConfig) (*DiskUsage, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("Passed in config cannot be nil")
 	}

--- a/checkers/disk/disk_usage_test.go
+++ b/checkers/disk/disk_usage_test.go
@@ -1,9 +1,10 @@
-package checkers
+package diskchk
 
 import (
-	. "github.com/onsi/gomega"
 	"os"
 	"testing"
+
+	. "github.com/onsi/gomega"
 )
 
 func TestNewDiskUsage(t *testing.T) {
@@ -11,8 +12,8 @@ func TestNewDiskUsage(t *testing.T) {
 
 	t.Run("Happy path and set thresholds", func(t *testing.T) {
 		cfg := &DiskUsageConfig{
-			Path: os.TempDir(),
-			WarningThreshold: 5,
+			Path:              os.TempDir(),
+			WarningThreshold:  5,
 			CriticalThreshold: 5,
 		}
 
@@ -58,8 +59,8 @@ func TestValidateDiskUsageConfig(t *testing.T) {
 
 	t.Run("Should error if warning threshold value set out of bounds", func(t *testing.T) {
 		cfg := &DiskUsageConfig{
-			Path: os.TempDir(),
-			WarningThreshold: -1,
+			Path:              os.TempDir(),
+			WarningThreshold:  -1,
 			CriticalThreshold: 100,
 		}
 
@@ -70,8 +71,8 @@ func TestValidateDiskUsageConfig(t *testing.T) {
 
 	t.Run("Should error if critical threshold value set out of bounds", func(t *testing.T) {
 		cfg := &DiskUsageConfig{
-			Path: os.TempDir(),
-			WarningThreshold: 10,
+			Path:              os.TempDir(),
+			WarningThreshold:  10,
 			CriticalThreshold: 101,
 		}
 
@@ -87,8 +88,8 @@ func TestDiskUsageStatus(t *testing.T) {
 
 	t.Run("Should error when critical threshold reached", func(t *testing.T) {
 		cfg := &DiskUsageConfig{
-			Path: "/unknown/path",
-			WarningThreshold: 50.0,
+			Path:              "/unknown/path",
+			WarningThreshold:  50.0,
 			CriticalThreshold: 50.0,
 		}
 
@@ -104,8 +105,8 @@ func TestDiskUsageStatus(t *testing.T) {
 
 	t.Run("Should error when critical threshold reached", func(t *testing.T) {
 		cfg := &DiskUsageConfig{
-			Path: os.TempDir(),
-			WarningThreshold: 90,
+			Path:              os.TempDir(),
+			WarningThreshold:  90,
 			CriticalThreshold: 1,
 		}
 
@@ -119,11 +120,10 @@ func TestDiskUsageStatus(t *testing.T) {
 		Expect(err.Error()).To(ContainSubstring("Critical: disk usage too high"))
 	})
 
-
 	t.Run("Should error when warning threshold reached", func(t *testing.T) {
 		cfg := &DiskUsageConfig{
-			Path: os.TempDir(),
-			WarningThreshold: 1,
+			Path:              os.TempDir(),
+			WarningThreshold:  1,
 			CriticalThreshold: 99,
 		}
 
@@ -138,8 +138,8 @@ func TestDiskUsageStatus(t *testing.T) {
 
 	t.Run("Shouldn't return error when everything is ok", func(t *testing.T) {
 		cfg := &DiskUsageConfig{
-			Path: os.TempDir(),
-			WarningThreshold: 99,
+			Path:              os.TempDir(),
+			WarningThreshold:  99,
 			CriticalThreshold: 99,
 		}
 

--- a/checkers/memcache/memcached.go
+++ b/checkers/memcache/memcached.go
@@ -1,11 +1,12 @@
-package checkers
+package memcachechk
 
 import (
 	"bytes"
 	"fmt"
-	"github.com/bradfitz/gomemcache/memcache"
 	"net"
 	"net/url"
+
+	"github.com/bradfitz/gomemcache/memcache"
 )
 
 const (
@@ -20,11 +21,11 @@ const (
 // "Timeout" defines timeout for socket write/read (useful for servers hosted on different machine)
 // "Ping" is optional; Ping establishes tcp connection to memcached server.
 type MemcachedConfig struct {
-	Url        string
-	Timeout    int32
-	Ping       bool
-	Set        *MemcachedSetOptions
-	Get        *MemcachedGetOptions
+	Url     string
+	Timeout int32
+	Ping    bool
+	Set     *MemcachedSetOptions
+	Get     *MemcachedGetOptions
 }
 
 type MemcachedClient interface {
@@ -33,7 +34,7 @@ type MemcachedClient interface {
 }
 
 type Memcached struct {
-	Config *MemcachedConfig
+	Config  *MemcachedConfig
 	wrapper *MemcachedClientWrapper
 }
 
@@ -77,7 +78,7 @@ func NewMemcached(cfg *MemcachedConfig) (*Memcached, error) {
 	mcWrapper := &MemcachedClientWrapper{memcache.New(cfg.Url)}
 
 	return &Memcached{
-		Config: cfg,
+		Config:  cfg,
 		wrapper: mcWrapper,
 	}, nil
 }
@@ -98,7 +99,7 @@ func (mc *Memcached) Status() (interface{}, error) {
 	}
 
 	if mc.Config.Get != nil {
-		val, err := mc.wrapper.GetClient().Get(mc.Config.Get.Key);
+		val, err := mc.wrapper.GetClient().Get(mc.Config.Get.Key)
 		if err != nil {
 			if err == memcache.ErrCacheMiss {
 				if !mc.Config.Get.NoErrorMissingKey {
@@ -158,6 +159,7 @@ func validateMemcachedConfig(cfg *MemcachedConfig) error {
 
 	return nil
 }
+
 // Used to simplify testing routines
 type MemcachedClientWrapper struct {
 	MemcachedClient

--- a/checkers/memcache/memcached_test.go
+++ b/checkers/memcache/memcached_test.go
@@ -1,12 +1,13 @@
-package checkers
+package memcachechk
 
 import (
 	"fmt"
-	"github.com/bradfitz/gomemcache/memcache"
-	. "github.com/onsi/gomega"
 	"math/rand"
 	"strconv"
 	"testing"
+
+	"github.com/bradfitz/gomemcache/memcache"
+	. "github.com/onsi/gomega"
 )
 
 const (
@@ -21,7 +22,7 @@ func TestNewMemcached(t *testing.T) {
 	t.Run("Happy path", func(t *testing.T) {
 		url := testUrl
 		cfg := &MemcachedConfig{
-			Url: url,
+			Url:  url,
 			Ping: true,
 		}
 		mc, server, err := setupMemcached(cfg)
@@ -43,7 +44,7 @@ func TestNewMemcached(t *testing.T) {
 	t.Run("Memcached should contain Client and Config", func(t *testing.T) {
 		url := testUrl
 		cfg := &MemcachedConfig{
-			Url: url,
+			Url:  url,
 			Ping: true,
 		}
 		mc, err := NewMemcached(cfg)
@@ -118,7 +119,7 @@ func TestValidateMemcachedConfig(t *testing.T) {
 		cfg := &MemcachedConfig{
 			Url: testUrl,
 			Get: &MemcachedGetOptions{
-				Key: "should_return_valid",
+				Key:    "should_return_valid",
 				Expect: []byte("should_return_valid"),
 			},
 		}
@@ -210,7 +211,7 @@ func TestMemcachedStatus(t *testing.T) {
 		t.Run("should use default .Value if .Value is set to empty string", func(t *testing.T) {
 			cfg := &MemcachedConfig{
 				Set: &MemcachedSetOptions{
-					Key: "should_return_default",
+					Key:   "should_return_default",
 					Value: "",
 				},
 			}
@@ -337,13 +338,13 @@ func setupMemcached(cfg *MemcachedConfig) (*Memcached, *MockServer, error) {
 	cfg.Url = testUrl
 	checker := &Memcached{
 		wrapper: &MemcachedClientWrapper{&MockMemcachedClient{}},
-		Config: cfg,
+		Config:  cfg,
 	}
 
 	return checker, server, nil
 }
 
-type MockServer struct {}
+type MockServer struct{}
 
 func (s *MockServer) Close() {
 	emulateServerShutdown = true
@@ -353,7 +354,7 @@ func (s *MockServer) Reset() {
 	emulateServerShutdown = false
 }
 
-type MockMemcachedClient struct {}
+type MockMemcachedClient struct{}
 
 func (m *MockMemcachedClient) Get(key string) (item *memcache.Item, err error) {
 	if emulateServerShutdown {

--- a/checkers/mongo/mongo.go
+++ b/checkers/mongo/mongo.go
@@ -1,9 +1,10 @@
-package checkers
+package mongochk
 
 import (
 	"fmt"
-	"github.com/globalsign/mgo"
 	"time"
+
+	"github.com/globalsign/mgo"
 )
 
 const (

--- a/checkers/mongo/mongo_test.go
+++ b/checkers/mongo/mongo_test.go
@@ -1,11 +1,12 @@
-package checkers
+package mongochk
 
 import (
 	"fmt"
-	. "github.com/onsi/gomega"
-	"github.com/zaffka/mongodb-boltdb-mock/db"
 	"testing"
 	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/zaffka/mongodb-boltdb-mock/db"
 )
 
 func TestNewMongo(t *testing.T) {

--- a/checkers/redis/redis.go
+++ b/checkers/redis/redis.go
@@ -1,4 +1,4 @@
-package checkers
+package redischk
 
 import (
 	"crypto/tls"

--- a/checkers/redis/redis_test.go
+++ b/checkers/redis/redis_test.go
@@ -1,4 +1,4 @@
-package checkers
+package redischk
 
 import (
 	"fmt"


### PR DESCRIPTION
As previously discussed in #56 this PR moves all checkers with external deps into sub packages. So, people using the checkers need to install only deps to checkers that they are really using.