### PR TITLE
Add OnComplete hook to health check config

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ This library:
 * Exposes a way for you to gather the check results in a *fast* and *thread-safe* manner to help determine the final status of your `/status` endpoint. **[2]**
 * Comes bundled w/ [pre-built checkers](/checkers) for well-known dependencies such as `Redis`, `Mongo`, `HTTP` and more.
 * Makes it simple to implement and provide your own checkers (by adhering to the checker interface).
-* Allows you to trigger listener functions when your health checks fail or recover using the `IStatusListener` interface.
-* Allows you to run custom logic when a specific health check completes by using the `OnComplete` hook.
+* Allows you to trigger listener functions when your health checks fail or recover using the [`IStatusListener` interface](#oncomplete-hook-vs-istatuslistener).
+* Allows you to run custom logic when a specific health check completes by using the [`OnComplete` hook](#oncomplete-hook-vs-istatuslistener).
 
 **[1]** Make sure to run your checks on a "sane" interval - ie. if you are checking your
 Redis dependency once every five minutes, your service is essentially running _blind_

--- a/checkers/README.md
+++ b/checkers/README.md
@@ -43,168 +43,173 @@ The SQL DB checker has implementations for the following interfaces:
 - `SQLQueryer`, which encloses `QueryContext` in [`sql.DB`](https://golang.org/pkg/database/sql/#DB.QueryContext), [`sql.Conn`](https://golang.org/pkg/database/sql/#Conn.QueryContext), [`sql.Stmt`](https://golang.org/pkg/database/sql/#Stmt.QueryContext), and [`sql.Tx`](https://golang.org/pkg/database/sql/#Tx.QueryContext)
 - `SQLExecer`, which encloses `ExecContext` in [`sql.DB`](https://golang.org/pkg/database/sql/#DB.ExecContext), [`sql.Conn`](https://golang.org/pkg/database/sql/#Conn.ExecContext), [`sql.Stmt`](https://golang.org/pkg/database/sql/#Stmt.ExecContext), and [`sql.Tx`](https://golang.org/pkg/database/sql/#Tx.ExecContext)
 
-      	#### SQLConfig
-      	The `SQLConfig` struct is required when using the SQL DB health check.  It **must** contain an inplementation of one of either `SQLPinger`, `SQLQueryer`, or `SQLExecer`.
+#### SQLConfig
+The `SQLConfig` struct is required when using the SQL DB health check.  It **must** contain an inplementation of one of either `SQLPinger`, `SQLQueryer`, or `SQLExecer`.
 
-      	If `SQLQueryer` or `SQLExecer` are implemented, then `Query` must be valid (len > 0).
+If `SQLQueryer` or `SQLExecer` are implemented, then `Query` must be valid (len > 0).
 
-      	Additionally, if `SQLQueryer` or `SQLExecer` are implemented, you have the option to also set either the `QueryerResultHandler` or `ExecerResultHandler` functions.  These functions allow you to evaluate the result of a query or exec operation.  If you choose not to implement these yourself, the default handlers are used.
+Additionally, if `SQLQueryer` or `SQLExecer` are implemented, you have the option to also set either the `QueryerResultHandler` or `ExecerResultHandler` functions.  These functions allow you to evaluate the result of a query or exec operation.  If you choose not to implement these yourself, the default handlers are used.
 
-      	The default `ExecerResultHandler` is successful if the passed exec operation affected one and only one row.
+The default `ExecerResultHandler` is successful if the passed exec operation affected one and only one row.
 
-      	The default `QueryerResultHandler` is successful if the passed query operation returned one and only one row.
+The default `QueryerResultHandler` is successful if the passed query operation returned one and only one row.
 
-      	#### SQLPinger
+#### SQLPinger
+Use the `SQLPinger` interface if your health check is only concerned with your application's database connectivity. All you need to do is set the `Pinger` value in your `SQLConfig`.
 
-  Use the `SQLPinger` interface if your health check is only concerned with your application's database connectivity. All you need to do is set the `Pinger` value in your `SQLConfig`.
+```golang
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return err
+	}
 
-      	```golang
-      	db, err := sql.Open("mysql", dsn)
-      	if err != nil {
-      		return err
-      	}
+	sqlCheck, err := checkers.NewSQL(&checkers.SQLConfig{
+		Pinger: db
+	})
+	if err != nil {
+		return err
+	}
 
-      	sqlCheck, err := checkers.NewSQL(&checkers.SQLConfig{
-      		Pinger: db
-      	})
-      	if err != nil {
-      		return err
-      	}
+	hc := health.New()
+	healthCheck.AddCheck(&health.Config{
+		Name:     "sql-check",
+		Checker:  sqlCheck,
+		Interval: time.Duration(3) * time.Second,
+		Fatal:    true,
+	})
+```
 
-      	hc := health.New()
-      	healthCheck.AddCheck(&health.Config{
-      		Name:     "sql-check",
-      		Checker:  sqlCheck,
-      		Interval: time.Duration(3) * time.Second,
-      		Fatal:    true,
-      	})
-      	```
+#### SQLQueryer
+Use the `SQLQueryer` interface if your health check requires you to read rows from your database.  You can optionally supply a query result handler function.  If you don't supply one, the default function will be used.  The function signature for the handler is:
 
-      	#### SQLQueryer
-      	Use the `SQLQueryer` interface if your health check requires you to read rows from your database.  You can optionally supply a query result handler function.  If you don't supply one, the default function will be used.  The function signature for the handler is:
+```golang
+type SQLQueryerResultHandler func(rows *sql.Rows) (bool, error)
+```
+The default query handler returns true if there was exactly one row in the resultset:
 
-      	```golang
-      	type SQLQueryerResultHandler func(rows *sql.Rows) (bool, error)
-      	```
-      	The default query handler returns true if there was exactly one row in the resultset:
+```golang
+	func DefaultQueryHandler(rows *sql.Rows) (bool, error) {
+		defer rows.Close()
 
-      	```golang
-      	func DefaultQueryHandler(rows *sql.Rows) (bool, error) {
-      		defer rows.Close()
+		numRows := 0
+		for rows.Next() {
+			numRows++
+		}
 
-      		numRows := 0
-      		for rows.Next() {
-      			numRows++
-      		}
+		return numRows == 1, nil
+	}
+```
 
-      		return numRows == 1, nil
-      	}
-      	```
-      	**IMPORTANT**: Note that your query handler is responsible for closing the passed `*sql.Rows` value.
+**IMPORTANT**: Note that your query handler is responsible for closing the passed `*sql.Rows` value.
 
-      	Sample `SQLQueryer` implementation:
+Sample `SQLQueryer` implementation:
 
-      	```golang
-      	// this is our custom query row handler
-      	func myQueryHandler(rows *sql.Rows) (bool, error) {
-      		defer rows.Close()
+```golang
+	// this is our custom query row handler
+	func myQueryHandler(rows *sql.Rows) (bool, error) {
+		defer rows.Close()
 
-      		var healthValue string
-      		for rows.Next() {
-      			// this query will ever return at most one row
-      			if err := rows.Scan(&healthValue); err != nil {
-      				return false, err
-      			}
-      		}
+		var healthValue string
+		for rows.Next() {
+			// this query will ever return at most one row
+			if err := rows.Scan(&healthValue); err != nil {
+				return false, err
+			}
+		}
 
-      		return healthValue == "ok", nil
-      	}
+		return healthValue == "ok", nil
+	}
 
-      	db, err := sql.Open("mysql", dsn)
-      	if err != nil {
-      		return err
-      	}
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return err
+	}
 
-      	// we pass the id we are looking for inside the params value
-      	sqlCheck, err := checkers.NewSQL(&checkers.SQLConfig{
-      		Queryerer:            db,
-      		Query:                "SELECT healthValue FROM some_table WHERE id = ?",
-      		Params:               []interface{}{1},
-      		QueryerResultHandler: myQueryHandler
-      	})
-      	if err != nil {
-      		return err
-      	}
+	// we pass the id we are looking for inside the params value
+	sqlCheck, err := checkers.NewSQL(&checkers.SQLConfig{
+		Queryerer:            db,
+		Query:                "SELECT healthValue FROM some_table WHERE id = ?",
+		Params:               []interface{}{1},
+		QueryerResultHandler: myQueryHandler
+	})
+	if err != nil {
+		return err
+	}
 
-      	hc := health.New()
-      	healthCheck.AddCheck(&health.Config{
-      		Name:     "sql-check",
-      		Checker:  sqlCheck,
-      		Interval: time.Duration(3) * time.Second,
-      		Fatal:    true,
-      	})
-      	```
+	hc := health.New()
+	healthCheck.AddCheck(&health.Config{
+		Name:     "sql-check",
+		Checker:  sqlCheck,
+		Interval: time.Duration(3) * time.Second,
+		Fatal:    true,
+	})
+```
 
-      	#### SQLExecer
-      	Use the `SQLExecer` interface if your health check requires you to update or insert to your database.  You can optionally supply an exec result handler function.  If you don't supply one, the default function will be used.  The function signature for the handler is:
+#### SQLExecer
+Use the `SQLExecer` interface if your health check requires you to update or insert to your database.  You can optionally supply an exec result handler function.  If you don't supply one, the default function will be used.  The function signature for the handler is:
 
-      	```golang
-      	type SQLExecerResultHandler func(result sql.Result) (bool, error)
-      	```
-      	The default exec handler returns true if there was exactly one affected row:
+```golang
+type SQLExecerResultHandler func(result sql.Result) (bool, error)
+```
 
-      	```golang
-      	func DefaultExecHandler(result sql.Result) (bool, error) {
-      		affectedRows, err := result.RowsAffected()
-      		if err != nil {
-      			return false, err
-      		}
+The default exec handler returns true if there was exactly one affected row:
 
-      		return affectedRows == int64(1), nil
-      	}
-      	```
+```golang
+	func DefaultExecHandler(result sql.Result) (bool, error) {
+		affectedRows, err := result.RowsAffected()
+		if err != nil {
+			return false, err
+		}
 
-      	Sample `SQLExecer ` implementation:
+		return affectedRows == int64(1), nil
+	}
+```
 
-      	```golang
-      	// this is our custom exec result handler
-      	func myExecHandler(result sql.Result) (bool, error) {
-      		insertId, err := result.LastInsertId()
-      		if err != nil {
-      			return false, err
-      		}
+Sample `SQLExecer ` implementation:
 
-      		// for this example, a check isn't valid
-      		// until after the 100th iteration
-      		return insertId > int64(100), nil
-      	}
+```golang
+	// this is our custom exec result handler
+	func myExecHandler(result sql.Result) (bool, error) {
+		insertId, err := result.LastInsertId()
+		if err != nil {
+			return false, err
+		}
 
-      	db, err := sql.Open("mysql", dsn)
-      	if err != nil {
-      		return err
-      	}
+		// for this example, a check isn't valid
+		// until after the 100th iteration
+		return insertId > int64(100), nil
+	}
 
-      	sqlCheck, err := checkers.NewSQL(&checkers.SQLConfig{
-      		Execer:              db,
-      		Query:               "INSERT INTO checks (checkTS) VALUES (NOW())",
-      		ExecerResultHandler: myExecHandler
-      	})
-      	if err != nil {
-      		return err
-      	}
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return err
+	}
 
-      	hc := health.New()
-      	healthCheck.AddCheck(&health.Config{
-      		Name:     "sql-check",
-      		Checker:  sqlCheck,
-      		Interval: time.Duration(3) * time.Second,
-      		Fatal:    true,
-      	})
-      	```
+	sqlCheck, err := checkers.NewSQL(&checkers.SQLConfig{
+		Execer:              db,
+		Query:               "INSERT INTO checks (checkTS) VALUES (NOW())",
+		ExecerResultHandler: myExecHandler
+	})
+	if err != nil {
+		return err
+	}
+
+	hc := health.New()
+	healthCheck.AddCheck(&health.Config{
+		Name:     "sql-check",
+		Checker:  sqlCheck,
+		Interval: time.Duration(3) * time.Second,
+		Fatal:    true,
+	})
+```
 
 ### Mongo
 
-Planned, but PR's welcome!
+Mongo checker allows you to test if an instance of MongoDB is available by using the underlying driver's ping method or check whether a collection exists or not.
+
+To make use of it, initialize a `MongoConfig` struct and pass it to `checkers.NewMongo(...)`.
+
+The `MongoConfig` struct must specify either one or both of the `Ping` or `Collection` fields.
 
 ### Reachable
 

--- a/examples/on-complete-hook/README.md
+++ b/examples/on-complete-hook/README.md
@@ -1,0 +1,34 @@
+# OnComplete Hook
+
+A function can be registered with the `OnComplete` hook by providing a func to the `OnComplete` field of the `health.Config` struct when setting up your health check. The function should have the following signature: `func (state *health.State)`.
+The field can be left out entirely or set to `nil` if you do not wish to register a function with the hook.
+
+Here is a simple example of configuring a `OnComplete` hook for a health check:
+
+```golang
+func main() {
+    // Create a new health instance
+    h := health.New()
+
+    // Instantiate your custom check
+    cc := &customCheck{}
+
+    // Add the checks to the health instance
+    h.AddChecks([]*health.Config{
+        {
+            Name:     "good-check",
+            Checker:  cc,
+            Interval: time.Duration(2) * time.Second,
+            Fatal:    true,
+            OnComplete: MyHookFunc
+        },
+    })
+
+    ...
+}
+
+func MyHookFunc(state *health.State) {
+    log.Println("The state of %s is %s", state.Name, state.Status)
+    // Other custom logic here...
+}
+```

--- a/health.go
+++ b/health.go
@@ -273,7 +273,7 @@ func (h *Health) startRunner(cfg *Config, ticker *time.Ticker, stop <-chan struc
 		h.safeUpdateState(stateEntry)
 
 		if cfg.OnComplete != nil {
-			cfg.OnComplete(stateEntry)
+			go cfg.OnComplete(stateEntry)
 		}
 	}
 

--- a/health.go
+++ b/health.go
@@ -83,6 +83,9 @@ type Config struct {
 	// Fatal marks a failing health check so that the
 	// entire health check request fails with a 500 error
 	Fatal bool
+
+	// Hook that gets called when this health check is complete
+	OnComplete func(state *State)
 }
 
 // State is a struct that contains the results of the latest
@@ -268,6 +271,10 @@ func (h *Health) startRunner(cfg *Config, ticker *time.Ticker, stop <-chan struc
 		}
 
 		h.safeUpdateState(stateEntry)
+
+		if cfg.OnComplete != nil {
+			cfg.OnComplete(stateEntry)
+		}
 	}
 
 	go func() {

--- a/health_test.go
+++ b/health_test.go
@@ -535,10 +535,10 @@ func TestStartRunner(t *testing.T) {
 		Expect(h.Failed()).To(BeTrue())
 	})
 
-	t.Run("Should call the onComplete hook when the health check is complete", func(t *testing.T) {
+	t.Run("Should call the OnComplete hook when the health check is complete", func(t *testing.T) {
 		checker := &fakes.FakeICheckable{}
 
-		var calledState *State = nil
+		var calledState *State
 		called := false
 		completeFunc := func(state *State) {
 			called = true
@@ -571,6 +571,52 @@ func TestStartRunner(t *testing.T) {
 		Expect(calledState).ToNot(BeNil())
 		Expect(calledState.Name).To(Equal(cfgs[0].Name))
 		Expect(calledState.Status).To(Equal("ok"))
+	})
+
+	t.Run("Modifying the state in the OnComplete hook should not modify the one saved in the states map", func(t *testing.T) {
+		checker := &fakes.FakeICheckable{}
+
+		var calledState *State
+		called := false
+		changedName := "Guybrush Threepwood"
+		changedStatus := "never"
+		completeFunc := func(state *State) {
+			called = true
+			state.Name = changedName
+			state.Status = changedStatus
+			calledState = state
+		}
+
+		cfgs := []*Config{
+			{
+				Name:       "CheckIt",
+				Checker:    checker,
+				Interval:   testCheckInterval,
+				Fatal:      false,
+				OnComplete: completeFunc,
+			},
+		}
+
+		h, _, err := setupRunners(cfgs, nil)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(h).ToNot(BeNil())
+
+		// Brittle...
+		time.Sleep(time.Duration(15) * time.Millisecond)
+
+		// Did the ticker fire and create a state entry?
+		Expect(h.states).To(HaveKey(cfgs[0].Name))
+
+		// Hook should have been called
+		Expect(called).To(BeTrue())
+		Expect(calledState).ToNot(BeNil())
+
+		//changed status in OnComplete should not affect internal states map
+		Expect(calledState.Name).To(Equal(changedName))
+		Expect(calledState.Status).To(Equal(changedStatus))
+		Expect(h.states[cfgs[0].Name].Name).To(Equal(cfgs[0].Name))
+		Expect(h.states[cfgs[0].Name].Status).To(Equal("ok"))
 	})
 }
 


### PR DESCRIPTION
This adds an `OnComplete` hook that will be called when the health check is complete.
It can be defined when creating the config for a health check.
```go
Health.AddCheck(&health.Config{
		Name:     "myCheck",
		Checker:  checker,
		Interval: time.Duration(1) * time.Second,
		Fatal:    false,
                OnComplete: func(state *health.State){ ... },
	})
```