### PR TITLE
Omit empty fields of State struct

### DIFF
--- a/health.go
+++ b/health.go
@@ -101,7 +101,7 @@ type State struct {
 	Err string `json:"error,omitempty"`
 
 	// Fatal shows if the check will affect global result
-	Fatal bool `json:"fatal,omitempty"`
+	Fatal bool `json:"fatal"`
 
 	// Details contains more contextual detail about a
 	// failing health check.

--- a/health.go
+++ b/health.go
@@ -92,7 +92,7 @@ type Config struct {
 // run of a particular check.
 type State struct {
 	// Name of the health check
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	// Status of the health check state ("ok" or "failed")
 	Status string `json:"status"`
@@ -108,10 +108,10 @@ type State struct {
 	Details interface{} `json:"details,omitempty"` // contains JSON message (that can be marshaled)
 
 	// CheckTime is the time of the last health check
-	CheckTime time.Time `json:"check_time"`
+	CheckTime time.Time `json:"check_time,omitempty"`
 
-	ContiguousFailures int64     `json:"num_failures"`     // the number of failures that occurred in a row
-	TimeOfFirstFailure time.Time `json:"first_failure_at"` // the time of the initial transitional failure for any given health check
+	ContiguousFailures int64     `json:"num_failures,omitempty"`     // the number of failures that occurred in a row
+	TimeOfFirstFailure time.Time `json:"first_failure_at,omitempty"` // the time of the initial transitional failure for any given health check
 }
 
 // indicates state is failure


### PR DESCRIPTION
There are cases where some of the fields are presented in the serialized State without meaningful value.
For example if a component's status is ok there is still fields `first_failure_at` and `num_failures` with zero values. 

Also there are situation where State struct could be used as a DTO for the overall status of the system, in this cases it is useful `name` and `check_time` also to be omitted since they also will be empty.

Also the Fatal field must be presented always so you know if a check is fatal or not. Not only presented for the fatal checks and omitted for all non fatal checks.