### PR TITLE
Fix DATA-DOG/go-sqlmock dependency

### DIFF
--- a/checkers/sql_test.go
+++ b/checkers/sql_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 )
 
 const execSQL = "UPDATE some_table"


### PR DESCRIPTION
Running `go mod tidy` results in the following error:

```
go mod tidy
go: finding gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.3
github.com/myuser/myapp/pkg/health imports
	github.com/InVisionApp/go-health/checkers tested by
	github.com/InVisionApp/go-health/checkers.test imports
	gopkg.in/DATA-DOG/go-sqlmock.v1: cannot find module providing package gopkg.in/DATA-DOG/go-sqlmock.v1
```

This PR should fix the dependency.

See also for further reference:
* https://github.com/DATA-DOG/go-sqlmock/issues/161
* https://github.com/heptiolabs/healthcheck/pull/24
