### PR TITLE
Fix module

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ For _full_ examples, look through the [examples dir](examples/)
 
 ```golang
 import (
-	health "github.com/InVisionApp/go-health"
-	"github.com/InVisionApp/go-health/checkers"
-	"github.com/InVisionApp/go-health/handlers"
+	health "github.com/InVisionApp/go-health/v2"
+	"github.com/InVisionApp/go-health/v2/checkers"
+	"github.com/InVisionApp/go-health/v2/handlers"
 )
 
 // Create a new health instance

--- a/checkers/reachable_test.go
+++ b/checkers/reachable_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/InVisionApp/go-health/checkers"
-	"github.com/InVisionApp/go-health/fakes"
-	"github.com/InVisionApp/go-health/fakes/netfakes"
+	"github.com/InVisionApp/go-health/v2/checkers"
+	"github.com/InVisionApp/go-health/v2/fakes"
+	"github.com/InVisionApp/go-health/v2/fakes/netfakes"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/checkers/sql_test.go
+++ b/checkers/sql_test.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"testing"
 
-	. "github.com/onsi/gomega"
 	"github.com/DATA-DOG/go-sqlmock"
+	. "github.com/onsi/gomega"
 )
 
 const execSQL = "UPDATE some_table"

--- a/examples/custom-checker-server/custom-checker-server.go
+++ b/examples/custom-checker-server/custom-checker-server.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/InVisionApp/go-health"
-	"github.com/InVisionApp/go-health/handlers"
+	"github.com/InVisionApp/go-health/v2"
+	"github.com/InVisionApp/go-health/v2/handlers"
 )
 
 type customCheck struct{}

--- a/examples/simple-http-server/simple-http-server.go
+++ b/examples/simple-http-server/simple-http-server.go
@@ -6,9 +6,9 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/InVisionApp/go-health"
-	"github.com/InVisionApp/go-health/checkers"
-	"github.com/InVisionApp/go-health/handlers"
+	"github.com/InVisionApp/go-health/v2"
+	"github.com/InVisionApp/go-health/v2/checkers"
+	"github.com/InVisionApp/go-health/v2/handlers"
 )
 
 func main() {

--- a/examples/status-listener/service/service.go
+++ b/examples/status-listener/service/service.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/InVisionApp/go-health"
-	"github.com/InVisionApp/go-health/checkers"
-	"github.com/InVisionApp/go-health/handlers"
+	"github.com/InVisionApp/go-health/v2"
+	"github.com/InVisionApp/go-health/v2/checkers"
+	"github.com/InVisionApp/go-health/v2/handlers"
 )
 
 var svcLogger *log.Logger

--- a/fakes/ireachabledatadogincrementer.go
+++ b/fakes/ireachabledatadogincrementer.go
@@ -4,7 +4,7 @@ package fakes
 import (
 	"sync"
 
-	"github.com/InVisionApp/go-health/checkers"
+	"github.com/InVisionApp/go-health/v2/checkers"
 )
 
 type FakeReachableDatadogIncrementer struct {

--- a/fakes/isqlexecer.go
+++ b/fakes/isqlexecer.go
@@ -6,7 +6,7 @@ import (
 	"database/sql"
 	"sync"
 
-	"github.com/InVisionApp/go-health/checkers"
+	"github.com/InVisionApp/go-health/v2/checkers"
 )
 
 type FakeSQLExecer struct {

--- a/fakes/isqlpinger.go
+++ b/fakes/isqlpinger.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/InVisionApp/go-health/checkers"
+	"github.com/InVisionApp/go-health/v2/checkers"
 )
 
 type FakeSQLPinger struct {

--- a/fakes/isqlqueryer.go
+++ b/fakes/isqlqueryer.go
@@ -6,7 +6,7 @@ import (
 	"database/sql"
 	"sync"
 
-	"github.com/InVisionApp/go-health/checkers"
+	"github.com/InVisionApp/go-health/v2/checkers"
 )
 
 type FakeSQLQueryer struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/InVisionApp/go-health
+module github.com/InVisionApp/go-health/v2
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.3.3

--- a/handlers/README.md
+++ b/handlers/README.md
@@ -9,9 +9,9 @@ it at a handler func.
 
 ```golang
 import (
-    "github.com/InVisionApp/go-health"
-    "github.com/InVisionApp/go-health/checkers"
-    "github.com/InVisionApp/go-health/handlers"
+    "github.com/InVisionApp/go-health/v2"
+    "github.com/InVisionApp/go-health/v2/checkers"
+    "github.com/InVisionApp/go-health/v2/handlers"
 )
 
 // create and configure a new health instance

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/InVisionApp/go-health"
+	"github.com/InVisionApp/go-health/v2"
 )
 
 type jsonStatus struct {

--- a/health.go
+++ b/health.go
@@ -2,7 +2,7 @@
 //
 // For additional overview, documentation and contribution guidelines, refer to the project's "README.md".
 //
-// For example usage, refer to https://module github.com/InVisionApp/go-health/v2/tree/master/examples/simple-http-server.
+// For example usage, refer to https://github.com/InVisionApp/go-health/tree/master/examples/simple-http-server.
 package health
 
 import (

--- a/health.go
+++ b/health.go
@@ -2,7 +2,7 @@
 //
 // For additional overview, documentation and contribution guidelines, refer to the project's "README.md".
 //
-// For example usage, refer to https://github.com/InVisionApp/go-health/tree/master/examples/simple-http-server.
+// For example usage, refer to https://module github.com/InVisionApp/go-health/v2/tree/master/examples/simple-http-server.
 package health
 
 import (

--- a/health_shared_test.go
+++ b/health_shared_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/InVisionApp/go-health/fakes"
+	"github.com/InVisionApp/go-health/v2/fakes"
 	"github.com/InVisionApp/go-logger"
 )
 

--- a/health_test.go
+++ b/health_test.go
@@ -8,7 +8,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	"github.com/InVisionApp/go-health/fakes"
+	"github.com/InVisionApp/go-health/v2/fakes"
 	"github.com/InVisionApp/go-logger"
 	"github.com/InVisionApp/go-logger/shims/testlog"
 )


### PR DESCRIPTION
Starting at v2, the module path must end in the major version.

The fakes were updated manually, which is not ideal. They seem
to have been edited manually before. I had tried to regenerate
but the tests wouldn't run.

Fixes #70