### PR TITLE
set active flag to false on stop

### DIFF
--- a/health.go
+++ b/health.go
@@ -219,6 +219,9 @@ func (h *Health) Stop() error {
 	// Reset states
 	h.safeResetStates()
 
+	// Checkers are now inactive
+	h.active.setFalse()	
+
 	return nil
 }
 


### PR DESCRIPTION
In the Stop function I added:
```go
h.active.setFalse()
```
This allows the checkers to go from Started to Stopped to Started again.
Before the change, once stopped, the checkers couldn't be started again.

